### PR TITLE
fixed left stick axes, added DashboardSystem, changed drive port numbers

### DIFF
--- a/src/org/_2585robophiles/frc2015/Environment.java
+++ b/src/org/_2585robophiles/frc2015/Environment.java
@@ -3,6 +3,7 @@ package org._2585robophiles.frc2015;
 import org._2585robophiles.frc2015.input.InputMethod;
 import org._2585robophiles.frc2015.input.XboxInput;
 import org._2585robophiles.frc2015.systems.AccelerometerSystem;
+import org._2585robophiles.frc2015.systems.DashboardSystem;
 import org._2585robophiles.frc2015.systems.GyroSystem;
 import org._2585robophiles.frc2015.systems.WheelSystem;
 import org._2585robophiles.lib2585.RobotEnvironment;
@@ -18,7 +19,8 @@ public class Environment extends RobotEnvironment {
 	private GyroSystem gyroSystem;
 	private AccelerometerSystem accelerometerSystem;
 	private InputMethod input;
-	
+	private DashboardSystem dashboardSystem;
+
 	/**
 	 * Just a default constructor
 	 */
@@ -43,6 +45,9 @@ public class Environment extends RobotEnvironment {
 				
 		wheelSystem = new WheelSystem();
 		wheelSystem.init(this);
+		
+		dashboardSystem = new DashboardSystem();
+		dashboardSystem.init(this);
 	}
 
 	/**
@@ -90,7 +95,7 @@ public class Environment extends RobotEnvironment {
 	/**
 	 * @return the accelerometerSystem
 	 */
-	public synchronized AccelerometerSystem getAccelerometerSystem() {
+	public AccelerometerSystem getAccelerometerSystem() {
 		return accelerometerSystem;
 	}
 
@@ -102,6 +107,20 @@ public class Environment extends RobotEnvironment {
 		this.accelerometerSystem = accelerometerSystem;
 	}
 
+	/**
+	 * @return the dashboardSystem
+	 */
+	public DashboardSystem getDashboardSystem() {
+		return dashboardSystem;
+	}
+
+	/**
+	 * @param dashboardSystem the dashboardSystem to set
+	 */
+	protected synchronized void setDashboardSystem(DashboardSystem dashboardSystem) {
+		this.dashboardSystem = dashboardSystem;
+	}
+	
 	/* (non-Javadoc)
 	 * @see org._2585robophiles.lib2585.Destroyable#destroy()
 	 */

--- a/src/org/_2585robophiles/frc2015/RobotMap.java
+++ b/src/org/_2585robophiles/frc2015/RobotMap.java
@@ -5,11 +5,11 @@ package org._2585robophiles.frc2015;
  */
 public interface RobotMap {
 
-	public static final int FRONT_LEFT_DRIVE = 1,
-							FRONT_RIGHT_DRIVE = 2,
-							REAR_LEFT_DRIVE = 3,
-							REAR_RIGHT_DRIVE = 4,
-							SIDEWAYS_DRIVE = 5;
+	public static final int FRONT_LEFT_DRIVE = 0,
+							FRONT_RIGHT_DRIVE = 1,
+							REAR_LEFT_DRIVE = 2,
+							REAR_RIGHT_DRIVE = 3,
+							SIDEWAYS_DRIVE = 4;
 	
 	public static final int GYRO = 1;
 	

--- a/src/org/_2585robophiles/frc2015/TeleopExecuter.java
+++ b/src/org/_2585robophiles/frc2015/TeleopExecuter.java
@@ -32,6 +32,7 @@ public class TeleopExecuter extends RunnableExecuter implements Initializable {
 	@Override
 	public void init(Environment environment) {
 		getRunnables().add(environment.getWheelSystem());
+		getRunnables().add(environment.getDashboardSystem());
 	}
 
 }

--- a/src/org/_2585robophiles/frc2015/input/XboxInput.java
+++ b/src/org/_2585robophiles/frc2015/input/XboxInput.java
@@ -31,7 +31,7 @@ public class XboxInput implements InputMethod {
 	 */
 	@Override
 	public double forwardMovement() {
-		return (-controller.getRawAxis(XboxConstants.LEFT_Y_AXIS));
+		return (-controller.getRawAxis(1));// left stick y-axis
 	}
 
 	/* (non-Javadoc)
@@ -39,7 +39,7 @@ public class XboxInput implements InputMethod {
 	 */
 	@Override
 	public double sidewaysMovement() {
-		return (-controller.getRawAxis(XboxConstants.LEFT_X_AXIS));
+		return (-controller.getRawAxis(0));// left stick x-axis
 	}
 
 	/* (non-Javadoc)

--- a/src/org/_2585robophiles/frc2015/systems/DashboardSystem.java
+++ b/src/org/_2585robophiles/frc2015/systems/DashboardSystem.java
@@ -1,0 +1,40 @@
+package org._2585robophiles.frc2015.systems;
+
+import org._2585robophiles.frc2015.Environment;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class DashboardSystem implements RobotSystem, Runnable {
+	
+	private AccelerometerSystem accelerometer;
+	private GyroSystem gyro;
+
+	/* (non-Javadoc)
+	 * @see org._2585robophiles.frc2015.Initializable#init(org._2585robophiles.frc2015.Environment)
+	 */
+	@Override
+	public void init(Environment environment) {
+		accelerometer = environment.getAccelerometerSystem();
+		gyro = environment.getGyroSystem();
+	}
+	
+	/* (non-Javadoc)
+	 * @see java.lang.Runnable#run()
+	 */
+	@Override
+	public void run() {
+		SmartDashboard.putNumber("X Acceleration", accelerometer.accelerationX());
+		SmartDashboard.putNumber("Y Acceleration", accelerometer.accelerationY());
+		SmartDashboard.putNumber("Z Acceleration", accelerometer.accelerationZ());
+		SmartDashboard.putNumber("Heading", gyro.heading());
+	}
+	
+	/* (non-Javadoc)
+	 * @see org._2585robophiles.lib2585.Destroyable#destroy()
+	 */
+	@Override
+	public void destroy() {
+		
+	}
+
+}


### PR DESCRIPTION
The axes for Xbox 360 controllers are no longer the same so different values are used for the axes of the left analog stick. A DashboardSystem was created and added to Environment and TeleopExecuter. The port numbers for the drivetrain motors were changed.