### PR TITLE
fixed and using PartnerXboxInput, encoder index, ground setpoint button

### DIFF
--- a/src/org/_2585robophiles/frc2015/Environment.java
+++ b/src/org/_2585robophiles/frc2015/Environment.java
@@ -1,7 +1,7 @@
 package org._2585robophiles.frc2015;
 
 import org._2585robophiles.frc2015.input.InputMethod;
-import org._2585robophiles.frc2015.input.XboxInput;
+import org._2585robophiles.frc2015.input.PartnerXboxInput;
 import org._2585robophiles.frc2015.systems.AccelerometerSystem;
 import org._2585robophiles.frc2015.systems.DashboardSystem;
 import org._2585robophiles.frc2015.systems.GyroSystem;
@@ -37,7 +37,7 @@ public class Environment extends RobotEnvironment {
 	public Environment(Robot robot) {
 		super(robot);
 		
-		input = new XboxInput();
+		input = new PartnerXboxInput();
 		gyroSystem = new GyroSystem();
 		accelerometerSystem = new AccelerometerSystem();
 		wheelSystem = new WheelSystem();

--- a/src/org/_2585robophiles/frc2015/RobotMap.java
+++ b/src/org/_2585robophiles/frc2015/RobotMap.java
@@ -19,6 +19,7 @@ public interface RobotMap {
 	public static final int GYRO = 1;
 	public static final int ENCODER_A_CHANNEL = 2;
 	public static final int ENCODER_B_CHANNEL = 3;
+	public static final int ENCODER_INDEX_CHANNEL = 4;
 	
 	public static final double FORWARD_RAMPING = .8;
 	public static final double SIDEWAYS_RAMPING = .8;

--- a/src/org/_2585robophiles/frc2015/input/InputMethod.java
+++ b/src/org/_2585robophiles/frc2015/input/InputMethod.java
@@ -73,6 +73,11 @@ public interface InputMethod {
 	public abstract boolean liftSetpoint4();
 	
 	/**
+	 * @return input to make the lift go to the ground setpoints
+	 */
+	public abstract boolean groundLift();
+	
+	/**
 	 * @return an array of joysticks used for input
 	 */
 	public abstract Joystick[] joysticks();

--- a/src/org/_2585robophiles/frc2015/input/JoystickInput.java
+++ b/src/org/_2585robophiles/frc2015/input/JoystickInput.java
@@ -112,6 +112,14 @@ public class JoystickInput implements InputMethod {
 	public boolean liftSetpoint4() {
 		return false;
 	}
+	
+	/* (non-Javadoc)
+	 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+	 */
+	@Override
+	public boolean groundLift() {
+		return false;
+	}
 
 	/* (non-Javadoc)
 	 * @see org._2585robophiles.frc2015.input.InputMethod#joysticks()
@@ -120,4 +128,5 @@ public class JoystickInput implements InputMethod {
 	public Joystick[] joysticks() {
 		return new Joystick[] {left , right};
 	}
+
 }

--- a/src/org/_2585robophiles/frc2015/input/PartnerXboxInput.java
+++ b/src/org/_2585robophiles/frc2015/input/PartnerXboxInput.java
@@ -73,7 +73,7 @@ public class PartnerXboxInput implements InputMethod {
 	 */
 	@Override
 	public double analogLiftDown() {
-		return Math.min(0, controller2.getRawAxis(1));// left y lift driver when going down
+		return -Math.min(0, -controller2.getRawAxis(1));// left y lift driver when going down
 	}
 
 	/* (non-Javadoc)
@@ -81,7 +81,7 @@ public class PartnerXboxInput implements InputMethod {
 	 */
 	@Override
 	public boolean liftSetpointDown() {
-		return controller2.getRawAxis(3) > 0.15;// right trigger
+		return controller2.getRawAxis(3) > 0;// right trigger
 	}
 
 	/* (non-Javadoc)
@@ -122,6 +122,14 @@ public class PartnerXboxInput implements InputMethod {
 	@Override
 	public boolean liftSetpoint4() {
 		return controller2.getRawButton(XboxConstants.Y_BUTTON);
+	}
+	
+	/* (non-Javadoc)
+	 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+	 */
+	@Override
+	public boolean groundLift() {
+		return controller2.getRawButton(XboxConstants.START_BUTTON);
 	}
 	
 	/* (non-Javadoc)

--- a/src/org/_2585robophiles/frc2015/input/XboxInput.java
+++ b/src/org/_2585robophiles/frc2015/input/XboxInput.java
@@ -123,6 +123,14 @@ public class XboxInput implements InputMethod {
 	}
 	
 	/* (non-Javadoc)
+	 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+	 */
+	@Override
+	public boolean groundLift() {
+		return controller.getRawButton(XboxConstants.START_BUTTON);
+	}
+	
+	/* (non-Javadoc)
 	 * @see org._2585robophiles.frc2015.input.InputMethod#joysticks()
 	 */
 	@Override

--- a/src/org/_2585robophiles/frc2015/systems/LiftSystem.java
+++ b/src/org/_2585robophiles/frc2015/systems/LiftSystem.java
@@ -30,6 +30,7 @@ public class LiftSystem implements RobotSystem, Runnable {
 	private double setpoint;
 	private boolean upPressed;
 	private boolean downPressed;
+	private boolean groundPressed;
 	private boolean setpoint1Pressed;
 	private boolean setpoint2Pressed;
 	private boolean setpoint3Pressed;
@@ -44,7 +45,7 @@ public class LiftSystem implements RobotSystem, Runnable {
 		input = environment.getInput();
 		leftMotor = new MultiMotor(new Victor[]{new Victor(RobotMap.LEFT_LIFT_1), new Victor(RobotMap.LEFT_LIFT_2)});
 		rightMotor = new MultiMotor(new Victor[]{new Victor(RobotMap.RIGHT_LIFT_1), new Victor(RobotMap.RIGHT_LIFT_2)});
-		encoder = new Encoder(RobotMap.ENCODER_A_CHANNEL, RobotMap.ENCODER_B_CHANNEL);
+		encoder = new Encoder(RobotMap.ENCODER_A_CHANNEL, RobotMap.ENCODER_B_CHANNEL, RobotMap.ENCODER_INDEX_CHANNEL);
 		encoder.setDistancePerPulse(3);
 		liftPID = new PIDSubsystem(0.3, 0.3, 0.3) {
 			
@@ -144,6 +145,9 @@ public class LiftSystem implements RobotSystem, Runnable {
 			else
 				setpoint = GROUND_SETPOINT;
 			enablePID();
+		}else if(input.groundLift() && !groundPressed){
+			setpoint = GROUND_SETPOINT;
+			enablePID();
 		}else if(input.liftSetpoint1() && !setpoint1Pressed){
 			setpoint = TOTE_PICKUP_1;
 			enablePID();
@@ -159,6 +163,7 @@ public class LiftSystem implements RobotSystem, Runnable {
 		}
 		upPressed = input.liftSetpointUp();
 		downPressed = input.liftSetpointDown();
+		groundPressed = input.groundLift();
 		setpoint1Pressed = input.liftSetpoint1();
 		setpoint2Pressed = input.liftSetpoint2();
 		setpoint3Pressed = input.liftSetpoint3();
@@ -235,7 +240,106 @@ public class LiftSystem implements RobotSystem, Runnable {
 	protected synchronized void setSetpoint(double setpoint) {
 		this.setpoint = setpoint;
 	}
+	
+	/**
+	 * @return the upPressed
+	 */
+	public synchronized boolean isUpPressed() {
+		return upPressed;
+	}
 
+	/**
+	 * @param upPressed the upPressed to set
+	 */
+	protected synchronized void setUpPressed(boolean upPressed) {
+		this.upPressed = upPressed;
+	}
+
+	/**
+	 * @return the downPressed
+	 */
+	public synchronized boolean isDownPressed() {
+		return downPressed;
+	}
+
+	/**
+	 * @param downPressed the downPressed to set
+	 */
+	protected synchronized void setDownPressed(boolean downPressed) {
+		this.downPressed = downPressed;
+	}
+
+	/**
+	 * @return the groundPressed
+	 */
+	public synchronized boolean isGroundPressed() {
+		return groundPressed;
+	}
+
+	/**
+	 * @param groundPressed the groundPressed to set
+	 */
+	protected synchronized void setGroundPressed(boolean groundPressed) {
+		this.groundPressed = groundPressed;
+	}
+
+	/**
+	 * @return the setpoint1Pressed
+	 */
+	public synchronized boolean isSetpoint1Pressed() {
+		return setpoint1Pressed;
+	}
+
+	/**
+	 * @param setpoint1Pressed the setpoint1Pressed to set
+	 */
+	protected synchronized void setSetpoint1Pressed(boolean setpoint1Pressed) {
+		this.setpoint1Pressed = setpoint1Pressed;
+	}
+
+	/**
+	 * @return the setpoint2Pressed
+	 */
+	public synchronized boolean isSetpoint2Pressed() {
+		return setpoint2Pressed;
+	}
+
+	/**
+	 * @param setpoint2Pressed the setpoint2Pressed to set
+	 */
+	protected synchronized void setSetpoint2Pressed(boolean setpoint2Pressed) {
+		this.setpoint2Pressed = setpoint2Pressed;
+	}
+
+	/**
+	 * @return the setpoint3Pressed
+	 */
+	public synchronized boolean isSetpoint3Pressed() {
+		return setpoint3Pressed;
+	}
+
+	/**
+	 * @param setpoint3Pressed the setpoint3Pressed to set
+	 */
+	protected synchronized void setSetpoint3Pressed(boolean setpoint3Pressed) {
+		this.setpoint3Pressed = setpoint3Pressed;
+	}
+
+	/**
+	 * @return the setpoint4Pressed
+	 */
+	public synchronized boolean isSetpoint4Pressed() {
+		return setpoint4Pressed;
+	}
+
+	/**
+	 * @param setpoint4Pressed the setpoint4Pressed to set
+	 */
+	protected synchronized void setSetpoint4Pressed(boolean setpoint4Pressed) {
+		this.setpoint4Pressed = setpoint4Pressed;
+	}
+
+	
 	/* (non-Javadoc)
 	 * @see org._2585robophiles.lib2585.Destroyable#destroy()
 	 */

--- a/test/org/_2585robophiles/frc2015/tests/LiftSystemTest.java
+++ b/test/org/_2585robophiles/frc2015/tests/LiftSystemTest.java
@@ -24,6 +24,7 @@ public class LiftSystemTest {
 	private boolean setpointUpInput;
 	private boolean setpointDownInput;
 	private boolean enabledPID;
+	private boolean ground;
 
 	/**
 	 * Set up before the test
@@ -136,6 +137,14 @@ public class LiftSystemTest {
 			public boolean liftSetpoint4() {
 				return liftSetpoint == 4;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return ground;
+			}
 		});
 	}
 
@@ -199,7 +208,30 @@ public class LiftSystemTest {
 		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
 		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.GROUND_SETPOINT));// we are already at lowest point
 		setpointDownInput = false;
-		setpointUpInput = true;
+		
+		// test going to each setpoint
+		ground = true;
+		lift.run();
+		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
+		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.GROUND_SETPOINT));
+		ground = false;
+		liftSetpoint = 1;
+		lift.run();
+		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
+		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.TOTE_PICKUP_1));
+		liftSetpoint = 2;
+		lift.run();
+		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.TOTE_PICKUP_2));
+		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
+		liftSetpoint = 3;
+		lift.run();
+		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
+		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.TOTE_PICKUP_3));
+		liftSetpoint = 4;
+		lift.run();
+		Assert.assertThat(enabledPID, CoreMatchers.equalTo(true));
+		Assert.assertThat(lift.getSetpoint(), CoreMatchers.equalTo(LiftSystem.TOTE_PICKUP_4));
+		liftSetpoint = 0;
 	}
 	
 	/**

--- a/test/org/_2585robophiles/frc2015/tests/WheelSystemTest.java
+++ b/test/org/_2585robophiles/frc2015/tests/WheelSystemTest.java
@@ -166,6 +166,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertEquals(0, currentRotation, 0);
@@ -269,12 +277,19 @@ public class WheelSystemTest {
 				return false;
 			}
 			
-
 			/* (non-Javadoc)
 			 * @see org._2585robophiles.frc2015.input.InputMethod#liftSetpointUp()
 			 */
 			@Override
 			public boolean liftSetpointUp() {
+				return false;
+			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
 				return false;
 			}
 
@@ -392,6 +407,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertEquals(0, currentRotation, 0);
@@ -499,6 +522,14 @@ public class WheelSystemTest {
 			 */
 			@Override
 			public boolean liftSetpoint4() {
+				return false;
+			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
 				return false;
 			}
 		});
@@ -614,6 +645,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertEquals(-1, currentRotation, 0);
@@ -720,6 +759,14 @@ public class WheelSystemTest {
 			 */
 			@Override
 			public boolean liftSetpoint4() {
+				return false;
+			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
 				return false;
 			}
 		});
@@ -832,6 +879,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertTrue(currentSidewaysMovement > 0);
@@ -940,6 +995,14 @@ public class WheelSystemTest {
 			 */
 			@Override
 			public boolean liftSetpoint4() {
+				return false;
+			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
 				return false;
 			}
 		});
@@ -1052,6 +1115,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertEquals(0, currentSidewaysMovement, 0);
@@ -1162,6 +1233,14 @@ public class WheelSystemTest {
 			public boolean liftSetpoint4() {
 				return false;
 			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
+				return false;
+			}
 		});
 		wheelSystem.run();
 		Assert.assertEquals(0, currentRotation, 0);
@@ -1269,6 +1348,14 @@ public class WheelSystemTest {
 			 */
 			@Override
 			public boolean liftSetpoint4() {
+				return false;
+			}
+
+			/* (non-Javadoc)
+			 * @see org._2585robophiles.frc2015.input.InputMethod#groundLift()
+			 */
+			@Override
+			public boolean groundLift() {
 				return false;
 			}
 		});


### PR DESCRIPTION
The start button now makes the lift go to the ground. We are using PartnerXboxInput in Environment. I took out the trigger deadzone for the right trigger on partner drive since that is not necessary. The problem with partner drive analog lift input has been fixed.