### PR TITLE
Remove warning suppression

### DIFF
--- a/src/org/_2585robophiles/frc2015/TeleopExecuter.java
+++ b/src/org/_2585robophiles/frc2015/TeleopExecuter.java
@@ -28,7 +28,6 @@ public class TeleopExecuter extends RunnableExecuter implements Initializable {
 	/* (non-Javadoc)
 	 * @see org._2585robophiles.frc2015.Initializable#init(org._2585robophiles.frc2015.Environment)
 	 */
-	@SuppressWarnings("unchecked")// not using generics so Lib2585 can remain compatible with Java ME
 	@Override
 	public void init(Environment environment) {
 		getRunnables().add(environment.getWheelSystem());


### PR DESCRIPTION
I removed an annotation that suppressed the warnings for not using generics in a Vector. The Vector is in Lib2585 which now makes use of generics. The annotation is no longer necessary as generics are now being used.